### PR TITLE
feat: Consolidated Version API

### DIFF
--- a/src/v2/controller/path.controller.ts
+++ b/src/v2/controller/path.controller.ts
@@ -11,7 +11,7 @@ import {
 	Path as URLPath,
 } from "tsoa";
 import { WriteConfirmation } from "firestorm-db";
-import { InputPath, Path, PathNewVersionParam, PathRemoveVersionParam } from "../interfaces";
+import { InputPath, Path } from "../interfaces";
 import PathService from "../service/path.service";
 
 @Route("paths")
@@ -36,44 +36,6 @@ export class PathsController extends Controller {
 	@Security("discord", ["Administrator"])
 	public createPath(@Body() body: InputPath): Promise<Path> {
 		return this.service.createPath(body);
-	}
-
-	/**
-	 * Add a version to existing paths
-	 * @param body Version name, edition it belongs to, and reference version if needed
-	 */
-	@Post("versions/add")
-	@Security("bot")
-	@Security("discord", ["Administrator"])
-	public addVersion(@Body() body: PathNewVersionParam): Promise<WriteConfirmation[]> {
-		// tsoa doesn't support tuples so we retype it as array (doesn't really matter)
-		return this.service.addVersion(body);
-	}
-
-	/**
-	 * Remove a version from existing paths
-	 * @param body Version name to remove
-	 */
-	@Post("versions/remove")
-	@Security("bot")
-	@Security("discord", ["Administrator"])
-	public removeVersion(@Body() body: PathRemoveVersionParam): Promise<WriteConfirmation[]> {
-		return this.service.removeVersion(body.version);
-	}
-
-	/**
-	 * Rename a version (e.g. 1.17 -> 1.17.1)
-	 * @param old_version Version to replace
-	 * @param new_version Version to replace with
-	 */
-	@Put("versions/rename/{old_version}/{new_version}")
-	@Security("bot")
-	@Security("discord", ["Administrator"])
-	public renameVersion(
-		@URLPath() old_version: string,
-		@URLPath() new_version: string,
-	): Promise<WriteConfirmation[]> {
-		return this.service.renameVersion(old_version, new_version);
 	}
 
 	/**

--- a/src/v2/controller/settings.controller.ts
+++ b/src/v2/controller/settings.controller.ts
@@ -53,7 +53,7 @@ export class SettingsController extends Controller {
 	@Post("/raw")
 	@Security("discord", ["Administrator"])
 	public async update(@Body() body: Record<string, unknown>): Promise<WriteConfirmation> {
-		await cache.purge(/settings-raw/g);
+		await cache.purge("settings-raw");
 		return this.settingsService.update(body);
 	}
 }

--- a/src/v2/controller/texture.controller.ts
+++ b/src/v2/controller/texture.controller.ts
@@ -18,7 +18,6 @@ import { Request as ExRequest } from "express";
 import { WriteConfirmation } from "firestorm-db";
 import {
 	AnyTextureProperty,
-	Edition,
 	EntireTextureToCreate,
 	PackID,
 	Texture,
@@ -84,23 +83,6 @@ export class TextureController extends Controller {
 	@Get("animated")
 	public getAnimated(): Promise<number[]> {
 		return this.service.getAnimated();
-	}
-
-	/**
-	 * Get all existing Minecraft versions supported in the database
-	 */
-	@Get("versions")
-	public getVersions(): Promise<string[]> {
-		return this.service.getVersions();
-	}
-
-	/**
-	 * Get all existing Minecraft versions for a given edition
-	 * @param edition Existing edition inside the settings collection
-	 */
-	@Get("versions/{edition}")
-	public getVersionByEdition(@Path() edition: Edition): Promise<string[]> {
-		return this.service.getVersionByEdition(edition);
 	}
 
 	/**

--- a/src/v2/controller/version.controller.ts
+++ b/src/v2/controller/version.controller.ts
@@ -21,8 +21,16 @@ export class VersionsController extends Controller {
 	 * Get a sorted list of all valid versions across editions
 	 */
 	@Get("list")
-	public getVersions(): Promise<string[]> {
-		return this.service.getFlat();
+	public getList(): Promise<string[]> {
+		return this.service.getList();
+	}
+
+	/**
+	 * Get a record of editions and their latest version
+	 */
+	@Get("latest")
+	public getLatest(): Promise<Record<Edition, string>> {
+		return this.service.getLatest();
 	}
 
 	/**

--- a/src/v2/controller/version.controller.ts
+++ b/src/v2/controller/version.controller.ts
@@ -20,7 +20,7 @@ export class VersionsController extends Controller {
 	/**
 	 * Get a sorted list of all valid versions across editions
 	 */
-	@Get("flat")
+	@Get("list")
 	public getVersions(): Promise<string[]> {
 		return this.service.getFlat();
 	}

--- a/src/v2/controller/version.controller.ts
+++ b/src/v2/controller/version.controller.ts
@@ -1,0 +1,73 @@
+import { Body, Controller, Delete, Get, Path, Post, Put, Route, Security, Tags } from "tsoa";
+import VersionService from "../service/version.service";
+import { Edition, NewVersionParam } from "../interfaces";
+import { WriteConfirmation } from "firestorm-db";
+
+@Route("versions")
+@Tags("Versions")
+export class VersionsController extends Controller {
+	private readonly service = new VersionService();
+
+	/**
+	 * Get a record of editions and their respective versions
+	 */
+	@Get("raw")
+	public getRaw(): Promise<Record<Edition, string[]>> {
+		return this.service.getRaw();
+	}
+
+	/**
+	 * Get a sorted list of all valid versions across editions
+	 */
+	@Get("flat")
+	public getVersions(): Promise<string[]> {
+		return this.service.getFlat();
+	}
+
+	/**
+	 * Get all existing Minecraft versions for a given edition
+	 * @param edition Existing edition inside the settings collection
+	 */
+	@Get("edition/{edition}")
+	public getVersionByEdition(@Path() edition: Edition): Promise<string[]> {
+		return this.service.getVersionByEdition(edition);
+	}
+
+	/**
+	 * Add a version to existing paths
+	 * @param body Version name, edition it belongs to, and reference version if needed
+	 */
+	@Post("")
+	@Security("bot")
+	@Security("discord", ["Administrator"])
+	public addVersion(@Body() body: NewVersionParam): Promise<WriteConfirmation[]> {
+		// tsoa doesn't support tuples so we retype it as array (doesn't really matter)
+		return this.service.add(body);
+	}
+
+	/**
+	 * Rename a version (e.g. 1.17 -> 1.17.1)
+	 * @param old_version Version to replace
+	 * @param new_version Version to replace with
+	 */
+	@Put("rename/{old_version}/{new_version}")
+	@Security("bot")
+	@Security("discord", ["Administrator"])
+	public renameVersion(
+		@Path() old_version: string,
+		@Path() new_version: string,
+	): Promise<WriteConfirmation[]> {
+		return this.service.rename(old_version, new_version);
+	}
+
+	/**
+	 * Remove a version from existing paths
+	 * @param body Version name to remove
+	 */
+	@Delete("{version}")
+	@Security("bot")
+	@Security("discord", ["Administrator"])
+	public deleteVersion(@Path() version: string): Promise<WriteConfirmation[]> {
+		return this.service.remove(version);
+	}
+}

--- a/src/v2/interfaces/index.ts
+++ b/src/v2/interfaces/index.ts
@@ -12,3 +12,4 @@ export * from "./users";
 export * from "./uses";
 export * from "./packs";
 export * from "./submissions";
+export * from "./versions";

--- a/src/v2/interfaces/paths.ts
+++ b/src/v2/interfaces/paths.ts
@@ -1,5 +1,4 @@
 import { WriteConfirmation } from "firestorm-db";
-import { Edition } from "./textures";
 
 export interface CreationPath {
 	name: string; // texture path ('textures/block/stone.png')
@@ -30,14 +29,4 @@ export interface PathRepository {
 	addNewVersionToVersion(version: string, newVersion: string): Promise<WriteConfirmation>;
 	removePathById(pathID: string): Promise<WriteConfirmation>;
 	removePathsByBulk(pathIDs: string[]): Promise<WriteConfirmation>;
-}
-
-export interface PathNewVersionParam {
-	edition: Edition;
-	version: string;
-	newVersion: string;
-}
-
-export interface PathRemoveVersionParam {
-	version: string;
 }

--- a/src/v2/interfaces/textures.ts
+++ b/src/v2/interfaces/textures.ts
@@ -90,8 +90,6 @@ export interface TextureRepository {
 	getResolutions(): Promise<number[]>;
 	getAnimated(): Promise<number[]>;
 	getTags(): Promise<string[]>;
-	getVersions(): Promise<string[]>;
-	getVersionByEdition(edition: Edition): Promise<string[]>;
 	createTexture(texture: TextureCreationParam): Promise<Texture>;
 	createTexturesBulk(textureArr: EntireTextureToCreate[]): Promise<Texture[]>;
 	editTexture(id: string, body: TextureCreationParam): Promise<Texture>;

--- a/src/v2/interfaces/versions.ts
+++ b/src/v2/interfaces/versions.ts
@@ -2,6 +2,6 @@ import { Edition } from "./textures";
 
 export interface NewVersionParam {
 	edition: Edition;
+	template?: string;
 	version: string;
-	newVersion: string;
 }

--- a/src/v2/interfaces/versions.ts
+++ b/src/v2/interfaces/versions.ts
@@ -1,0 +1,7 @@
+import { Edition } from "./textures";
+
+export interface NewVersionParam {
+	edition: Edition;
+	version: string;
+	newVersion: string;
+}

--- a/src/v2/repository/texture.repository.ts
+++ b/src/v2/repository/texture.repository.ts
@@ -1,6 +1,5 @@
 import { ID_FIELD, SearchOption, WriteConfirmation } from "firestorm-db";
 import {
-	Edition,
 	FirestormTexture,
 	PackID,
 	PropertyToOutput,
@@ -9,9 +8,7 @@ import {
 	TextureProperty,
 	TextureRepository,
 } from "../interfaces";
-import { NotFoundError } from "../tools/errorTypes";
-import { contributions, packs, paths, settings, textures, uses } from "../firestorm";
-import versionSorter from "../tools/versionSorter";
+import { contributions, packs, paths, textures, uses } from "../firestorm";
 
 export default class TextureFirestormRepository implements TextureRepository {
 	public getRaw(): Promise<Record<string, FirestormTexture>> {
@@ -128,23 +125,6 @@ export default class TextureFirestormRepository implements TextureRepository {
 	public async getTags(): Promise<string[]> {
 		const res = await textures.values({ field: "tags", flatten: true });
 		return res.sort();
-	}
-
-	public async getVersions(): Promise<string[]> {
-		const s = await settings.readRaw(true);
-		return Object.values(s.versions as string[])
-			.flat()
-			.sort(versionSorter)
-			.reverse();
-	}
-
-	public async getVersionByEdition(edition: Edition): Promise<string[]> {
-		const versions: Record<Edition, string[]> = await settings.get("versions");
-		if (!versions[edition])
-			throw new NotFoundError(
-				`Edition ${edition} not found. Available editions: ${Object.keys(versions).join(", ")}`,
-			);
-		return versions[edition];
 	}
 
 	public async createTexture(texture: TextureCreationParam): Promise<Texture> {

--- a/src/v2/service/gallery.service.ts
+++ b/src/v2/service/gallery.service.ts
@@ -1,6 +1,5 @@
-import { settings, textures, urlFromTextureData } from "../firestorm";
+import { textures, urlFromTextureData } from "../firestorm";
 import {
-	Edition,
 	GalleryModalResult,
 	GalleryResult,
 	MCMETA,
@@ -14,13 +13,16 @@ import PackService from "./pack.service";
 import PathService from "./path.service";
 import TextureService from "./texture.service";
 import UseService from "./use.service";
+import VersionService from "./version.service";
 
 export default class GalleryService {
-	private readonly pathService = new PathService();
+	private readonly textureService = new TextureService();
 
 	private readonly useService = new UseService();
 
-	private readonly textureService = new TextureService();
+	private readonly pathService = new PathService();
+
+	private readonly versionService = new VersionService();
 
 	private readonly packService = new PackService();
 
@@ -33,7 +35,7 @@ export default class GalleryService {
 	): Promise<string[]> {
 		const baseURL = "https://raw.githubusercontent.com";
 		const { github } = await this.packService.getById(pack);
-		const { versions } = (await settings.readRaw()) as { versions: Record<Edition, string[]> };
+		const versions = await this.versionService.getRaw();
 
 		return (
 			textureIDs

--- a/src/v2/service/gallery.service.ts
+++ b/src/v2/service/gallery.service.ts
@@ -35,7 +35,7 @@ export default class GalleryService {
 	): Promise<string[]> {
 		const baseURL = "https://raw.githubusercontent.com";
 		const { github } = await this.packService.getById(pack);
-		const versions = await this.versionService.getRaw();
+		const latestVersions = await this.versionService.getLatest();
 
 		return (
 			textureIDs
@@ -49,7 +49,7 @@ export default class GalleryService {
 					if (!packGithub) return "";
 
 					// convert "latest" to actual latest version
-					const githubVersion = version === "latest" ? versions[use.edition][0] : version;
+					const githubVersion = version === "latest" ? latestVersions[use.edition] : version;
 					return `${baseURL}/${packGithub.org}/${packGithub.repo}/${githubVersion}/${path}`;
 				})
 		);

--- a/src/v2/service/path.service.ts
+++ b/src/v2/service/path.service.ts
@@ -1,11 +1,8 @@
 import { WriteConfirmation } from "firestorm-db";
-import { BadRequestError, NotFoundError } from "../tools/errorTypes";
+import { BadRequestError } from "../tools/errorTypes";
 import UseService from "./use.service";
-import { InputPath, Path, PathNewVersionParam } from "../interfaces";
+import { InputPath, Path } from "../interfaces";
 import PathFirestormRepository from "../repository/path.repository";
-import TextureService from "./texture.service";
-import { settings } from "../firestorm";
-import versionSorter from "../tools/versionSorter";
 
 export default class PathService {
 	private readonly useService: UseService;
@@ -58,67 +55,6 @@ export default class PathService {
 
 		await this.useService.getUseByIdOrName(path.use); // verify use existence
 		return this.repo.updatePath(id, path);
-	}
-
-	async addVersion(body: PathNewVersionParam): Promise<[WriteConfirmation, WriteConfirmation]> {
-		// stupid workaround for recursion (the classes require each other)
-		const versions = await TextureService.getInstance().getVersionByEdition(body.edition);
-
-		// check existing version to the paths provided
-		if (!versions.includes(body.version))
-			throw new BadRequestError("Incorrect input path version provided");
-
-		return Promise.all([
-			settings.editField({
-				id: "versions",
-				field: body.edition,
-				operation: "array-splice",
-				// equivalent of array_unshift (new versions go at start of list)
-				value: [0, 0, body.newVersion],
-			}),
-			this.repo.addNewVersionToVersion(body.version, body.newVersion),
-		]);
-	}
-
-	async removeVersion(version: string): Promise<[WriteConfirmation, WriteConfirmation]> {
-		const allVersions: Record<string, string[]> = await settings.get("versions");
-		const edition = Object.entries(allVersions).find((v) => v[1].includes(version))?.[0];
-
-		if (!edition) throw new NotFoundError(`Matching edition not found for version ${version}`);
-
-		return Promise.all([
-			settings.editField({
-				id: "versions",
-				field: edition,
-				operation: "set",
-				value: allVersions[edition].filter((v) => v !== version),
-			}),
-			this.repo.removeVersion(version),
-		]);
-	}
-
-	async renameVersion(
-		oldVersion: string,
-		newVersion: string,
-	): Promise<[WriteConfirmation, WriteConfirmation]> {
-		const allVersions: Record<string, string[]> = await settings.get("versions");
-		const edition = Object.entries(allVersions).find((v) => v[1].includes(oldVersion))?.[0];
-		if (!edition) throw new NotFoundError(`Matching edition not found for version ${oldVersion}`);
-
-		return Promise.all([
-			settings.editField({
-				id: "versions",
-				field: edition,
-				operation: "set",
-				// map old version to new version, keep the rest the same
-				value: allVersions[edition]
-					.map((v) => (v === oldVersion ? newVersion : v))
-					.sort(versionSorter)
-					// newest at top
-					.reverse(),
-			}),
-			this.repo.renameVersion(oldVersion, newVersion),
-		]);
 	}
 
 	removePathById(pathID: string): Promise<WriteConfirmation> {

--- a/src/v2/service/texture.service.ts
+++ b/src/v2/service/texture.service.ts
@@ -1,7 +1,6 @@
 import { ID_FIELD, WriteConfirmation } from "firestorm-db";
 import {
 	CreationPath,
-	Edition,
 	EntireTextureToCreate,
 	EntireUseToCreate,
 	FirestormTexture,
@@ -120,14 +119,6 @@ export default class TextureService {
 
 	getTags(): Promise<string[]> {
 		return this.textureRepo.getTags();
-	}
-
-	getVersions(): Promise<string[]> {
-		return this.textureRepo.getVersions();
-	}
-
-	getVersionByEdition(edition: Edition): Promise<string[]> {
-		return this.textureRepo.getVersionByEdition(edition);
 	}
 
 	async mergeTextures(source: string, destination: string) {

--- a/src/v2/service/version.service.ts
+++ b/src/v2/service/version.service.ts
@@ -13,7 +13,18 @@ export default class VersionService {
 		return s.versions as Record<Edition, string[]>;
 	}
 
-	async getFlat(): Promise<string[]> {
+	async getLatest(): Promise<Record<Edition, string>> {
+		const versions = await this.getRaw();
+		return Object.entries(versions).reduce(
+			(acc, [edition, versions]) => {
+				acc[edition] = versions[0];
+				return acc;
+			},
+			{} as Record<Edition, string>,
+		);
+	}
+
+	async getList(): Promise<string[]> {
 		const versions = await this.getRaw();
 		return Object.values(versions).flat().sort(versionSorter).reverse();
 	}

--- a/src/v2/service/version.service.ts
+++ b/src/v2/service/version.service.ts
@@ -1,0 +1,89 @@
+import { WriteConfirmation } from "firestorm-db";
+import { BadRequestError, NotFoundError } from "../tools/errorTypes";
+import { settings } from "../firestorm";
+import PathFirestormRepository from "../repository/path.repository";
+import versionSorter from "../tools/versionSorter";
+import { Edition, NewVersionParam } from "../interfaces";
+
+export default class VersionService {
+	private readonly pathRepo = new PathFirestormRepository();
+
+	async getRaw(): Promise<Record<Edition, string[]>> {
+		const s = await settings.readRaw(true);
+		return s.versions as Record<Edition, string[]>;
+	}
+
+	async getFlat(): Promise<string[]> {
+		const versions = await this.getRaw();
+		return Object.values(versions).flat().sort(versionSorter).reverse();
+	}
+
+	async getVersionByEdition(edition: Edition): Promise<string[]> {
+		const versions: Record<Edition, string[]> = await settings.get("versions");
+		if (!versions[edition])
+			throw new NotFoundError(
+				`Edition ${edition} not found. Available editions: ${Object.keys(versions).join(", ")}`,
+			);
+		return versions[edition];
+	}
+
+	async add(body: NewVersionParam): Promise<[WriteConfirmation, WriteConfirmation]> {
+		const versions = await this.getVersionByEdition(body.edition);
+
+		// check existing version to the paths provided
+		if (!versions.includes(body.version))
+			throw new BadRequestError("Incorrect input path version provided");
+
+		return Promise.all([
+			settings.editField({
+				id: "versions",
+				field: body.edition,
+				operation: "array-splice",
+				// equivalent of array_unshift (new versions go at start of list)
+				value: [0, 0, body.newVersion],
+			}),
+			this.pathRepo.addNewVersionToVersion(body.version, body.newVersion),
+		]);
+	}
+
+	async rename(
+		oldVersion: string,
+		newVersion: string,
+	): Promise<[WriteConfirmation, WriteConfirmation]> {
+		const allVersions: Record<string, string[]> = await settings.get("versions");
+		const edition = Object.entries(allVersions).find((v) => v[1].includes(oldVersion))?.[0];
+		if (!edition) throw new NotFoundError(`Matching edition not found for version ${oldVersion}`);
+
+		return Promise.all([
+			settings.editField({
+				id: "versions",
+				field: edition,
+				operation: "set",
+				// map old version to new version, keep the rest the same
+				value: allVersions[edition]
+					.map((v) => (v === oldVersion ? newVersion : v))
+					.sort(versionSorter)
+					// newest at top
+					.reverse(),
+			}),
+			this.pathRepo.renameVersion(oldVersion, newVersion),
+		]);
+	}
+
+	async remove(version: string): Promise<[WriteConfirmation, WriteConfirmation]> {
+		const allVersions: Record<string, string[]> = await settings.get("versions");
+		const edition = Object.entries(allVersions).find((v) => v[1].includes(version))?.[0];
+
+		if (!edition) throw new NotFoundError(`Matching edition not found for version ${version}`);
+
+		return Promise.all([
+			settings.editField({
+				id: "versions",
+				field: edition,
+				operation: "set",
+				value: allVersions[edition].filter((v) => v !== version),
+			}),
+			this.pathRepo.removeVersion(version),
+		]);
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		"declaration": true,
 		"allowJs": true,
 		"strictNullChecks": true,
+		"strict": false,
 		"resolveJsonModule": true,
 	},
 	"exclude": [


### PR DESCRIPTION
**Note: This PR is related to https://github.com/Faithful-Resource-Pack/Web-App/pull/186.**

All of the version-related endpoints are currently spread out throughout the texture and path routes, and aren't particularly well organized. I consolidated all of these routes under one `/v2/versions/` namespace and made the naming much more intuitive. Much like the gallery namespace, it only uses a service class and doesn't actually rely on any firestorm-level collection code (aside from settings-related stuff), and only really serves as a nice abstraction over all of the stuff it's editing.

Consolidated routes:
<img width="1483" height="396" alt="Screenshot 2026-02-08 at 2 01 32 AM" src="https://github.com/user-attachments/assets/fa038102-c92b-4e86-9b9e-bdb1a08142bb" />
